### PR TITLE
Redirect fix

### DIFF
--- a/app/code/community/Creare/CreareSeoCore/Model/Observer.php
+++ b/app/code/community/Creare/CreareSeoCore/Model/Observer.php
@@ -206,7 +206,7 @@ class Creare_CreareSeoCore_Model_Observer extends Mage_Core_Model_Abstract
             $url        = $product->getUrlModel()
                 ->getUrl($product, array('_ignore_category' => true, '_query' => $query));
             $escapedUrl = Mage::helper('core/url')->escapeUrl($url);
-            if (Mage::helper('core/url')->getCurrentUrl() != $escapedUrl) {
+            if (Mage::helper('core/url')->escapeUrl(Mage::helper('core/url')->getCurrentUrl()) != $escapedUrl) {
                 Mage::app()->getFrontController()->getResponse()->setRedirect($url, 301);
                 Mage::app()->getResponse()->sendResponse();
             }


### PR DESCRIPTION
You should compare escaped urls because the CurrentUrl() fucntion returns parameter with & and and the escaped url has &amp; 
With this behaviour a redirect loop is caused.