### PR TITLE
G.Analytics changed position from to body to head

### DIFF
--- a/app/code/community/Creare/CreareSeoCore/Model/Observer.php
+++ b/app/code/community/Creare/CreareSeoCore/Model/Observer.php
@@ -351,7 +351,7 @@ class Creare_CreareSeoCore_Model_Observer extends Mage_Core_Model_Abstract {
         if (Mage::getStoreConfig('creareseocore/googleanalytics/type'))
         {
             $layout = $observer->getEvent()->getLayout();
-            $layout->getUpdate()->addUpdate('<reference name="after_body_start"><remove name="google_analytics" /><block type="creareseocore/googleanalytics_ua" name="universal_analytics" template="creareseo/googleanalytics/ua.phtml" /></reference>');
+            $layout->getUpdate()->addUpdate('<reference name="head" before="-"><remove name="google_analytics" /><block type="creareseocore/googleanalytics_ua" name="universal_analytics" template="creareseo/googleanalytics/ua.phtml" /></reference>');
             $layout->generateXml();
         }
     }


### PR DESCRIPTION
Magento from version 1.8 no more uses after_body_start
And of course Google require before </head> ends. https://support.google.com/analytics/answer/1008080?hl=en

maybe there should be better idea with check magento versions and returns different layout update